### PR TITLE
Some formatting fixes and check test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ from jax import lax
 n = 10_000
 
 @loop_tqdm(n)
-def step(i, val): 
+def step(i, val):
     return val + 1
 
 last_number = lax.fori_loop(0, n, step, 0)

--- a/jax_tqdm/__init__.py
+++ b/jax_tqdm/__init__.py
@@ -1,1 +1,1 @@
-from jax_tqdm.pbar import scan_tqdm, loop_tqdm
+from jax_tqdm.pbar import loop_tqdm, scan_tqdm

--- a/jax_tqdm/pbar.py
+++ b/jax_tqdm/pbar.py
@@ -65,7 +65,10 @@ def loop_tqdm(n: int, message: typing.Optional[str] = None) -> typing.Callable:
     _update_progress_bar, close_tqdm = build_tqdm(n, message)
 
     def _loop_tqdm(func):
-        """Decorator that adds a tqdm progress bar to `body_fun` used in `jax.lax.fori_loop`."""
+        """
+        Decorator that adds a tqdm progress bar to `body_fun`
+        used in `jax.lax.fori_loop`.
+        """
 
         def wrapper_progress_bar(i, val):
             _update_progress_bar(i)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,7 @@
 import jax.numpy as jnp
 from jax import lax
 
-from jax_tqdm import scan_tqdm, loop_tqdm
+from jax_tqdm import loop_tqdm, scan_tqdm
 
 
 def test_readme_scan_example():
@@ -15,6 +15,9 @@ def test_readme_scan_example():
 
     last_number, all_numbers = lax.scan(step, 0, jnp.arange(n))
 
+    assert int(last_number) == n
+    assert jnp.array_equal(all_numbers, 1 + jnp.arange(n))
+
 
 def test_readme_fori_loop_example():
     """Just test that README loop example runs correctly"""
@@ -22,7 +25,9 @@ def test_readme_fori_loop_example():
     n = 10_000
 
     @loop_tqdm(n)
-    def step(i, val): 
+    def step(i, val):
         return val + 1
 
     last_number = lax.fori_loop(0, n, step, 0)
+
+    assert int(last_number) == n


### PR DESCRIPTION
Just run the pre-commit linter, fix some formatting, and check correct test output (also as linter was complaining about unused variables in tests)