### PR TITLE
Fix Callback Sequence Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JAX-tqdm
+# JAX-Tqdm
 
 Add a [tqdm](https://github.com/tqdm/tqdm) progress bar to your JAX scans and loops.
 
@@ -10,9 +10,9 @@ Install with pip:
 pip install jax-tqdm
 ```
 
-## Example usage
+## Example Usage
 
-### in `jax.lax.scan`
+### In `jax.lax.scan`
 
 ```python
 from jax_tqdm import scan_tqdm
@@ -28,7 +28,7 @@ def step(carry, x):
 last_number, all_numbers = lax.scan(step, 0, jnp.arange(n))
 ```
 
-### in `jax.lax.fori_loop`
+### In `jax.lax.fori_loop`
 
 ```python
 from jax_tqdm import loop_tqdm
@@ -43,7 +43,7 @@ def step(i, val):
 last_number = lax.fori_loop(0, n, step, 0)
 ```
 
-### Scans & Loops Inside VMAP
+### Scans & Loops Inside Vmap
 
 For scans and loops inside a map, jax-tqdm can print stacked progress bars
 showing the individual progress of each process. To do this you can wrap
@@ -101,7 +101,7 @@ last_number, all_numbers = lax.scan(step, 0, jnp.arange(n))
 
 will update every other step.
 
-### Progress bar type
+### Progress Bar Type
 
 You can select the [tqdm](https://github.com/tqdm/tqdm) [submodule](https://github.com/tqdm/tqdm/tree/master?tab=readme-ov-file#submodules) manually with the `tqdm_type` option. The options are `'std'`, `'notebook'`, or `'auto'`.
 ```python
@@ -118,7 +118,7 @@ def step(carry, x):
 last_number, all_numbers = lax.scan(step, 0, jnp.arange(n))
 ```
 
-### Progress bar options
+### Progress Bar Options
 
 Any additional keyword arguments are passed to the [tqdm](https://github.com/tqdm/tqdm)
 progress bar constructor. For example:
@@ -137,7 +137,7 @@ def step(carry, x):
 last_number, all_numbers = lax.scan(step, 0, jnp.arange(n))
 ```
 
-## Why JAX-tqdm?
+## Why JAX-Tqdm?
 
 JAX functions are [pure](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#pure-functions),
 so side effects such as printing progress when running scans and loops are not allowed.

--- a/jax_tqdm/pbar.py
+++ b/jax_tqdm/pbar.py
@@ -175,7 +175,6 @@ def build_tqdm(
             total=n,
             position=bar_id + position_offset,
             desc=message,
-            leave=True,
             **kwargs,
         )
 
@@ -183,9 +182,10 @@ def build_tqdm(
         tqdm_bars[int(bar_id)].update(print_rate)
 
     def _close_tqdm(bar_id: int):
-        tqdm_bars[int(bar_id)].update(remainder)
-        tqdm_bars[int(bar_id)].clear()
-        tqdm_bars[int(bar_id)].close()
+        _pbar = tqdm_bars.pop(int(bar_id))
+        _pbar.update(remainder)
+        _pbar.clear()
+        _pbar.close()
 
     def update_progress_bar(carry: typing.Any, iter_num, bar_id: int = 0):
         """Updates tqdm from a JAX scan or loop"""

--- a/jax_tqdm/pbar.py
+++ b/jax_tqdm/pbar.py
@@ -84,7 +84,7 @@ def loop_tqdm(
 
     Parameters
     ----------
-    n : int
+    n: int
         Number of iterations.
     print_rate: int
         Optional integer rate at which the progress bar will be updated,
@@ -134,6 +134,18 @@ def build_tqdm(
 ) -> typing.Tuple[typing.Callable, typing.Callable]:
     """
     Build the tqdm progress bar on the host
+
+    Parameters
+    ----------
+    n: int
+        Number of updates
+    print_rate: int
+        Optional integer rate at which the progress bar will be updated,
+        If ``None`` the print rate will 1/20th of the total number of steps.
+    tqdm_type: str
+        Type of progress-bar, should be one of "auto", "std", or "notebook".
+    **kwargs
+        Extra keyword arguments to pass to tqdm.
     """
 
     if tqdm_type not in ("auto", "std", "notebook"):
@@ -187,7 +199,7 @@ def build_tqdm(
         _pbar.clear()
         _pbar.close()
 
-    def update_progress_bar(carry: typing.Any, iter_num, bar_id: int = 0):
+    def update_progress_bar(carry: typing.Any, iter_num: int, bar_id: int = 0):
         """Updates tqdm from a JAX scan or loop"""
 
         def _inner_init(_i, _carry):

--- a/jax_tqdm/pbar.py
+++ b/jax_tqdm/pbar.py
@@ -59,12 +59,12 @@ def scan_tqdm(
             if isinstance(carry, PBar):
                 bar_id = carry.id
                 carry = carry.carry
-                carry = update_progress_bar(carry, iter_num, bar_id=bar_id)
+                carry, x = update_progress_bar((carry, x), iter_num, bar_id=bar_id)
                 result = func(carry, x)
                 result = (PBar(id=bar_id, carry=result[0]), result[1])
                 return close_tqdm(result, iter_num, bar_id=bar_id)
             else:
-                carry = update_progress_bar(carry, iter_num)
+                carry, x = update_progress_bar((carry, x), iter_num)
                 result = func(carry, x)
                 return close_tqdm(result, iter_num)
 
@@ -112,12 +112,12 @@ def loop_tqdm(
             if isinstance(val, PBar):
                 bar_id = val.id
                 val = val.carry
-                val = update_progress_bar(val, i, bar_id=bar_id)
+                i, val = update_progress_bar((i, val), i, bar_id=bar_id)
                 result = func(i, val)
                 result = PBar(id=bar_id, carry=result)
                 return close_tqdm(result, i, bar_id=bar_id)
             else:
-                val = update_progress_bar(val, i)
+                i, val = update_progress_bar((i, val), i)
                 result = func(i, val)
                 return close_tqdm(result, i)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jax-tqdm"
-version = "0.3.0"
+version = "0.3.1"
 description = "Tqdm progress bar for JAX scans and loops"
 authors = [
     "Jeremie Coullon <jeremie.coullon@gmail.com>",


### PR DESCRIPTION
Fix bug where tqdm callbacks were not being correctly ordered around either side of computation. 

Also tweak how updates are performed:

- Initialise progress bar before first step
- Check for update every step before inner-function
- On final step, after inner-function, complete and close progress bar