### PR TITLE
Bounded while loop

### DIFF
--- a/jax_tqdm/__init__.py
+++ b/jax_tqdm/__init__.py
@@ -1,1 +1,1 @@
-from jax_tqdm.pbar import PBar, loop_tqdm, scan_tqdm
+from jax_tqdm.pbar import PBar, bounded_while_tqdm, loop_tqdm, scan_tqdm

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -65,14 +65,15 @@ def test_bounded_while_loop():
     n_total = 10_000
     n_stop = 5_000
 
-    @bounded_while_tqdm(n_total)
     def cond_fun(x):
         return x < n_stop
 
     def body_fun(x):
         return x + 1
 
-    result = jax.lax.while_loop(cond_fun, body_fun, 0)
+    cond_fun, body_fun = bounded_while_tqdm(cond_fun, body_fun, n=n_total)
+    init_val = PBar(carry=0)
+    result = jax.lax.while_loop(cond_fun, body_fun, init_val)
 
     assert result == 5_000
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -65,13 +65,12 @@ def test_bounded_while_loop():
     n_total = 10_000
     n_stop = 5_000
 
+    @bounded_while_tqdm(n_total)
     def cond_fun(x):
         return x < n_stop
 
     def body_fun(x):
         return x + 1
-
-    cond_fun, body_fun = bounded_while_tqdm(cond_fun, body_fun, n_total)
 
     result = jax.lax.while_loop(cond_fun, body_fun, 0)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from jax_tqdm import PBar, loop_tqdm, scan_tqdm
+from jax_tqdm import PBar, bounded_while_tqdm, loop_tqdm, scan_tqdm
 
 
 @pytest.mark.parametrize("print_rate", [None, 1, 10])
@@ -59,6 +59,23 @@ def test_vmap_w_scan(print_rate):
     assert jnp.array_equal(last_numbers, jnp.full((n_maps,), n))
     assert all_numbers.shape == (n_maps, 10_000)
     assert jnp.array_equal(all_numbers, jnp.tile(1 + jnp.arange(n), (n_maps, 1)))
+
+
+def test_bounded_while_loop():
+    n_total = 10_000
+    n_stop = 5_000
+
+    def cond_fun(x):
+        return x < n_stop
+
+    def body_fun(x):
+        return x + 1
+
+    cond_fun, body_fun = bounded_while_tqdm(cond_fun, body_fun, n_total)
+
+    result = jax.lax.while_loop(cond_fun, body_fun, 0)
+
+    assert result == 5_000
 
 
 @pytest.mark.parametrize("print_rate", [None, 1, 10])


### PR DESCRIPTION
*This is currently a prototype, may still have some bugs!*

Prototype of the API for bounded while loop mentioned in #24 

Since the progress-bar needs to be closed if the end condition is met, I think the simplest way to implement this is to decorate the condition function (as this is also called every step), and then the user needs to ensure the iteration number is part of the carried value.

This would look like

```python
n_total = 10_000
n_stop = 5_000

@bounded_while_tqdm(n_total)
def cond_fun(x):
    return x < n_stop

def body_fun(x):
    return x + 1

result = jax.lax.while_loop(cond_fun, body_fun, 0)
```

prints

```bash
50%|████████████████████▌                    | 5000/10000 [00:00<00:00, 3593474.98it/s]
```

At each iteration it performs the same update checks as the scan and look, but it checks if the condition has been met, and terminates the progress bar manually if so.

Any thoughts at @andrewlesak?