### PR TITLE
fix: re-export private import for type checkers

### DIFF
--- a/jax_tqdm/__init__.py
+++ b/jax_tqdm/__init__.py
@@ -1,3 +1,3 @@
-from jax_tqdm.base import PBar
-from jax_tqdm.loop_pbar import loop_tqdm
-from jax_tqdm.scan_pbar import scan_tqdm
+from jax_tqdm.base import PBar as PBar
+from jax_tqdm.loop_pbar import loop_tqdm as loop_tqdm
+from jax_tqdm.scan_pbar import scan_tqdm as scan_tqdm


### PR DESCRIPTION
Since imports are private by convention in Python, we re-export to demarcate them as public.

This prevents pylance and other type checkers from complaining.